### PR TITLE
I've added a Packages/manifest.json file for UGemini dependencies.

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "com.uralstech.ugemini": "https://github.com/Uralstech/UGemini.git#upm",
+    "com.uralstech.ucloud.operations": "https://github.com/Uralstech/UCloud.Operations.git#upm",
+    "com.uralstech.utils.singleton": "https://github.com/Uralstech/Utils.Singleton.git#upm",
+    "com.utilities.async": "https://github.com/RageAgainstThePixel/com.utilities.async.git",
+    "com.utilities.encoder.wav": "https://github.com/RageAgainstThePixel/com.utilities.encoder.wav.git"
+  }
+}


### PR DESCRIPTION
I created a Packages/manifest.json file to declare the dependencies required for the GeminiIntegrationTool, specifically the Uralstech.UGemini package and its related packages.

This should help Unity resolve the necessary libraries and fix compilation errors related to missing Uralstech.UGemini references.

The following packages were added:
- com.uralstech.ugemini
- com.uralstech.ucloud.operations
- com.uralstech.utils.singleton
- com.utilities.async
- com.utilities.encoder.wav

You will need to ensure your Unity project correctly utilizes this manifest, either by treating this repository as a local package or by incorporating these dependencies into your main project's manifest.